### PR TITLE
Fixed multi request formatting and version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ankiconnect Android is a from scratch unofficial reimplementation of the [deskto
 It reimplements the core APIs used by Yomichan to work with [Ankidroid](https://github.com/ankidroid/Anki-Android/).
 
 ## Instructions
-Here's how to set everything up from scratch (if you've already got Yomichan working then skip to step 5):
+Here's how to set everything up from scratch (if you've already got Yomichan working, then skip to step 5):
 
 1. Install [Kiwi Browser](https://play.google.com/store/apps/details?id=com.kiwibrowser.browser) and [Ankidroid](https://play.google.com/store/apps/details?id=com.ichi2.anki)
 2. Install Ankiconnect Android - [Download](https://github.com/KamWithK/AnkiconnectAndroid/releases)
@@ -20,6 +20,7 @@ Here's how to set everything up from scratch (if you've already got Yomichan wor
     * `Import` 1+ dictionaries by clicking `Configure installed and enabled dictionaries` and then `Import` under `Dictionaries` section ([external resources](https://learnjapanese.moe/resources/#dictionaries))
     * **`Scan modifier key` under the `Scanning` section should be "No Key" (unless using mouse/keyboard, advanced options contains more config options)**
     * `Scan delay` under the `Scanning` section can feel laggy and so can be set to `0`
+    * It is recommended to lower the value of `Maximum number of results` (under `General`) to prevent unnecessary lag. A sane value would be `8`.
 
 5. Set up Yomichan for sentence mining:
     * Toggle `Enable Anki integration` on, under `Anki`

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/Parser.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/Parser.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Type;
 import java.util.*;
 
 public class Parser {
-    public static Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    public static Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
 
     public static JsonObject parse(String raw_data) {
         return JsonParser.parseString(raw_data).getAsJsonObject();
@@ -16,6 +16,13 @@ public class Parser {
 
     public static String get_action(JsonObject data) {
         return data.get("action").getAsString();
+    }
+
+    public static int get_version(JsonObject data, int fallback) {
+        if (data.has("version")) {
+            return data.get("version").getAsInt();
+        }
+        return fallback;
     }
 
     public static String getDeckName(JsonObject raw_data) {


### PR DESCRIPTION
It seems like the multi request on the README of anki-connect is incorrect. For example, when I try to run the following on my PC:
```
{'action': 'multi', 'params': {'actions': [{'action': 'deckNames'}, {'action': 'findNotes', 'params': {'query': '"key:思春期"'}}]}, 'version': 6}
```

I get the following result:
```
{'result': [['Cloze Deletion', 'JPMN-Examples', 'Mining', 'Pitch Accent'], [1659230530092]], 'error': None}
```
which is different from the documentation, which states that each result is contained in a `{"result": ..., "error": ...}`.

Most importantly, this **appears to fix the duplicate card problem that many people (including myself) have been facing**, including #8, #10, and [this issue on Yomichan](https://github.com/FooSoft/yomichan/issues/2241).

To give a few more specifics on the issue, here is how you can replicate it:

- Select any word where the result list has at least one duplicate (i.e. the highlighted word itself need not to be a duplicate, but some word underneath it is a duplicate)
- Then the plus button does not appear for any word.

The example I ran into was for the word ハンター which is not a duplicate, but the word 班 appeared some entries below and was a duplicate.

~~EDIT: This looks like something to do with the `version` number being too low, and that isn't handled properly yet.~~