### PR TITLE
fix: Bumped min sdk version to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.kamwithk.ankiconnectandroid"
-        minSdk 21
+        minSdk 26
         targetSdk 33
         versionCode 9
         versionName "1.9"

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/MainActivity.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/MainActivity.java
@@ -3,12 +3,9 @@ package com.kamwithk.ankiconnectandroid;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Intent;
-import android.os.Build;
-import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 
@@ -20,7 +17,6 @@ public class MainActivity extends AppCompatActivity {
 
     public static final String CHANNEL_ID = "ankiConnectAndroid";
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
This PR simply cleans up the codebase a bit:
- minSdk is bumped to 26 because the app literally crashes on lower versions otherwise: `RequiresApi` is wrapped around `onCreate`, because `NotificationChannel` requires a minimum sdk version of 26 or above. If we try to run the app on lower Android versions, the app will attempt to run and fail at this step, because `NotificationChannel` doesn't exist.
- Removed `jcenter`, because the app still builds without it. This removes a warning about it being deprecated.
- Cleaned up a few unused imports in MainActivity. After all other PRs are merged, it should be safe to [optimize imports further](https://stackoverflow.com/questions/22273434/remove-unused-imports-in-android-studio) (to prevent any merge conflicts).