### PR TITLE
add support for the updateNoteFields api

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -103,20 +103,17 @@ public class IntegratedAPI {
         // Store media and create a field: enclosed_filename map to avoid O(n^2) lookup later
         Map<String, ArrayList<String>> field_to_files = new HashMap<>();
         for (RequestMedia media: media_to_add) {
-            // See note in common.RequestMedia
-            if (!media.isStored()) {
-                media.setFilename(mediaAPI.storeMediaFile(media.getFilename(), media.getData()));
-                media.setStored(true);
-            }
+            // mediaAPI.storeMediaFile() doesn't store as the passed in filename, need to use the returned one
+            String stored_filename = mediaAPI.storeMediaFile(media.getFilename(), media.getData());
 
             String enclosed_filename = "";
             switch (media.getType()) {
                 case AUDIO:
                 case VIDEO:
-                    enclosed_filename = "[sound:" + media.getFilename() + "]";
+                    enclosed_filename = "[sound:" + stored_filename + "]";
                     break;
                 case PICTURE:
-                    enclosed_filename = "<img src=\"" + media.getFilename() + "\">";
+                    enclosed_filename = "<img src=\"" + stored_filename + "\">";
                     break;
             }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -118,12 +118,10 @@ public class IntegratedAPI {
             }
 
             for (String field: media.getFields()) {
-                ArrayList<String> reverse_mapped_fields = field_to_files.get(field);
-                if (reverse_mapped_fields == null) {
-                    reverse_mapped_fields = new ArrayList<>();
+                if (!field_to_files.containsKey(field)) {
+                    field_to_files.put(field, new ArrayList<>());
                 }
-                reverse_mapped_fields.add(enclosed_filename);
-                field_to_files.put(field, reverse_mapped_fields);
+                field_to_files.get(field).add(enclosed_filename);
             }
         }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/MediaAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/MediaAPI.java
@@ -35,6 +35,7 @@ public class MediaAPI {
      */
     @SuppressLint("SetWorldReadable")
     public String storeMediaFile(String filename, byte[] data) throws IOException {
+        // TODO: investigate why filename gets a number attached to it, i.e. file.png -> file_123456789.png
         String lastPathSegment = Uri.parse(filename).getLastPathSegment();
         lastPathSegment = lastPathSegment == null ? filename : lastPathSegment;
         File file = new File(context.getCacheDir(), lastPathSegment);

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
@@ -65,6 +65,19 @@ public class NoteAPI {
         return note_does_not_exist;
     }
 
+    public String[] getNoteFields(long note_id) throws Exception {
+        return api.getNote(note_id).getFields();
+    }
+
+    public boolean updateNoteFields(long note_id, String[] fields) throws Exception {
+        return api.updateNoteFields(note_id, fields);
+    }
+
+    public long getNoteModelId(long note_id) throws Exception {
+        api.getNote(note_id); //set cursor to correct position
+        return api.getCurrentModelId();
+    }
+
     public ArrayList<Long> findNotes(String query) {
         ArrayList<Long> noteIds = new ArrayList<>();
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/RequestMedia.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/RequestMedia.java
@@ -5,17 +5,12 @@ import java.util.ArrayList;
 /**
  * Simple class that encodes the media passed into an addNote, updateNoteFields, etc request.
  * Currently very limited; only supports the type, data, filename, and fields[] part of the request.
- *
- * stored is metadata for whether it has already been stored in the Anki media folder. Used in
- * combination with setFilename() to ensure the file is only stored once despite
- * mediaAPI.storeMediaFile() not saving under the provided filename at the moment.
  */
 public class RequestMedia {
     private final RequestMediaTypes type;
     private final byte[] data;
-    private String filename;
+    private final String filename;
     private final ArrayList<String> fields;
-    private boolean stored;
 
     public enum RequestMediaTypes {
         AUDIO,
@@ -28,7 +23,6 @@ public class RequestMedia {
         this.data = data;
         this.filename = filename;
         this.fields = fields;
-        this.stored = false;
     }
 
     public RequestMediaTypes getType() {
@@ -43,19 +37,7 @@ public class RequestMedia {
         return filename;
     }
 
-    public void setFilename(String filename) {
-        this.filename = filename;
-    }
-
     public ArrayList<String> getFields() {
         return fields;
-    }
-
-    public boolean isStored() {
-        return stored;
-    }
-
-    public void setStored(boolean stored) {
-        this.stored = stored;
     }
 }

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/RequestMedia.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/RequestMedia.java
@@ -1,0 +1,61 @@
+package com.kamwithk.ankiconnectandroid.request_parsers;
+
+import java.util.ArrayList;
+
+/**
+ * Simple class that encodes the media passed into an addNote, updateNoteFields, etc request.
+ * Currently very limited; only supports the type, data, filename, and fields[] part of the request.
+ *
+ * stored is metadata for whether it has already been stored in the Anki media folder. Used in
+ * combination with setFilename() to ensure the file is only stored once despite
+ * mediaAPI.storeMediaFile() not saving under the provided filename at the moment.
+ */
+public class RequestMedia {
+    private final RequestMediaTypes type;
+    private final byte[] data;
+    private String filename;
+    private final ArrayList<String> fields;
+    private boolean stored;
+
+    public enum RequestMediaTypes {
+        AUDIO,
+        VIDEO,
+        PICTURE,
+    }
+
+    public RequestMedia(RequestMediaTypes type, byte[] data, String filename, ArrayList<String> fields) {
+        this.type = type;
+        this.data = data;
+        this.filename = filename;
+        this.fields = fields;
+        this.stored = false;
+    }
+
+    public RequestMediaTypes getType() {
+        return type;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public ArrayList<String> getFields() {
+        return fields;
+    }
+
+    public boolean isStored() {
+        return stored;
+    }
+
+    public void setStored(boolean stored) {
+        this.stored = stored;
+    }
+}

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/AnkiAPIRouting.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/AnkiAPIRouting.java
@@ -212,14 +212,12 @@ public class AnkiAPIRouting {
 
         return noteId;
     }
-    
+
     private String updateNoteFields(JsonObject raw_json) throws Exception {
         integratedAPI.updateNoteFields(
-                Parser.getNoteId(raw_json),
+                Parser.getUpdateNoteFieldsId(raw_json),
                 Parser.getUpdateNoteFieldsFields(raw_json),
-                Parser.getUpdateNoteFilesToAdd(raw_json),
-                Parser.getUpdateNoteMediaFieldsToFilenames(raw_json, "picture"),
-                Parser.getUpdateNoteMediaFieldsToFilenames(raw_json, "audio")
+                Parser.getUpdateNoteFieldsMedia(raw_json)
         );
         return "null";
     }

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/AnkiAPIRouting.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/AnkiAPIRouting.java
@@ -61,6 +61,8 @@ public class AnkiAPIRouting {
                 return canAddNotes(raw_json);
             case "addNote":
                 return addNote(raw_json);
+            case "updateNoteFields":
+                return updateNoteFields(raw_json);
             case "storeMediaFile":
                 return storeMediaFile(raw_json);
             case "multi":
@@ -209,6 +211,17 @@ public class AnkiAPIRouting {
         ));
 
         return noteId;
+    }
+    
+    private String updateNoteFields(JsonObject raw_json) throws Exception {
+        integratedAPI.updateNoteFields(
+                Parser.getNoteId(raw_json),
+                Parser.getUpdateNoteFieldsFields(raw_json),
+                Parser.getUpdateNoteFilesToAdd(raw_json),
+                Parser.getUpdateNoteMediaFieldsToFilenames(raw_json, "picture"),
+                Parser.getUpdateNoteMediaFieldsToFilenames(raw_json, "audio")
+        );
+        return "null";
     }
 
     private String storeMediaFile(JsonObject raw_json) throws Exception {

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,12 +86,17 @@ Do not expect the error message to be the exact same as the PC Anki-Connect erro
 * Anki-Connect desktop allows using various formats for the media file, but this api currently only
   supports using urls.
 
+### `updateNoteFields`
+* See: [Anki-Connect `updateNoteFields`](https://github.com/FooSoft/anki-connect#updatenotefields)
+* Does not support `url` or `skipHash` for media
+
 <br>
 
 ## Media Actions
 
 ### `storeMediaFile`
 * See: [Anki-Connect `storeMediaFile`](https://github.com/FooSoft/anki-connect#storemediafile)
+* Filenames will get a random number appended to the end of them, i.e. `file.png` becomes `file_123456789.png`
 * Used by Yomichan
 
 <br>


### PR DESCRIPTION
### Description
Adds support for the [updateNoteFields API](https://github.com/FooSoft/anki-connect#updatenotefields) to match the desktop AnkiConnect. There's a couple additional helper functions added as well that were needed to facilitate updateNoteFields.
### Example Request
```js
{
  action: 'updateNoteFields',
  version: 6,
  params: {
    note: {
      id: 1679779279219,
      fields: {
        Source: 'anime',
      },
      picture: [
        {
          data: image as base64 string,
          filename: 'screenshot.jpg',
          fields: ['Source'],
        },
      ],
    },
  },
}
```
### Limitations
Doesn't support URLs for files nor skipHash.
I only tested using images, though I uploaded them as audio/video to test the codepath and it worked fine.