### PR TITLE
Fix get note model

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
@@ -80,7 +80,7 @@ public class NoteAPI {
     public Long getNoteModelId(long note_id) {
         // Manually queries the note with a specific projection to get the model ID
         // Code copied/pasted from getNote() in AddContentAPI:
-        //
+        // https://github.com/ankidroid/Anki-Android/blob/1711e56c2b5515ab89c3424b60e60867bb65d492/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt#L244
 
         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(note_id));
         Cursor cursor = context.getContentResolver().query(noteUri, MODEL_PROJECTION, null, null, null);

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
@@ -2,15 +2,19 @@ package com.kamwithk.ankiconnectandroid.ankidroid_api;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.net.Uri;
 
 import com.ichi2.anki.FlashCardsContract;
 import com.ichi2.anki.api.AddContentApi;
+import com.ichi2.anki.api.NoteInfo;
 
 import java.util.*;
 
 public class NoteAPI {
     private Context context;
     private final AddContentApi api;
+
+    private static final String[] MODEL_PROJECTION = {FlashCardsContract.Note.MID};
 
     public NoteAPI(Context context) {
         this.context = context;
@@ -73,9 +77,25 @@ public class NoteAPI {
         return api.updateNoteFields(note_id, fields);
     }
 
-    public long getNoteModelId(long note_id) throws Exception {
-        api.getNote(note_id); //set cursor to correct position
-        return api.getCurrentModelId();
+    public Long getNoteModelId(long note_id) {
+        // Manually queries the note with a specific projection to get the model ID
+        // Code copied/pasted from getNote() in AddContentAPI:
+        //
+
+        Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(note_id));
+        Cursor cursor = context.getContentResolver().query(noteUri, MODEL_PROJECTION, null, null, null);
+        if (cursor == null) {
+            return null;
+        }
+        try {
+            if (!cursor.moveToNext()) {
+                return null;
+            }
+            int index = cursor.getColumnIndexOrThrow(FlashCardsContract.Note.MID);;
+            return cursor.getLong(index); // mid
+        } finally {
+            cursor.close();
+        }
     }
 
     public ArrayList<Long> findNotes(String query) {

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java
@@ -221,13 +221,24 @@ public class LocalAudioAPIRouting {
         byte[] data = audioFileEntryDao.getData(path, source);
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+        String mimeType = null;
         if (path.endsWith(".mp3")) {
-            return newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "audio/mpeg", new ByteArrayInputStream(data), data.length);
+            mimeType = "audio/mpeg";
         } else if (path.endsWith(".aac")) {
-            return newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "audio/aac", new ByteArrayInputStream(data), data.length);
-        } else {
-            return audioError("File is neither a .mp3 or .acc file: " + path);
+            mimeType = "audio/aac";
+        } else if (path.endsWith(".m4a")) {
+            mimeType = "audio/mp4";
+        } else if (path.endsWith(".ogg") || path.endsWith(".oga") || path.endsWith(".opus")) {
+            mimeType = "audio/ogg";
+        } else if (path.endsWith(".flac")) {
+            mimeType = "audio/flac";
+        } else if (path.endsWith(".wav")) {
+            mimeType = "audio/wav";
         }
+        if (mimeType == null) {
+            return audioError("File is not a supported audio file: " + path);
+        }
+        return newFixedLengthResponse(NanoHTTPD.Response.Status.OK, mimeType, new ByteArrayInputStream(data), data.length);
 
     }
 }


### PR DESCRIPTION
@Twinov I was playing around with `updateNoteFields`, and it seemed to be erroring due to having incorrect fields. This PR should fix it, and actually get the model ID of the note.

Note: Was testing the call with `adb shell` and `curl`
```
curl 'http://127.0.0.1:8765/' --data-raw '{"action":"updateNoteFields","version":6,"params":{"note": {"id": 1673427736656, "fields": {}}}}'
```