### PR TITLE
Support for common Forvo languages audio

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/Scraper.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/Scraper.java
@@ -24,6 +24,7 @@ public class Scraper {
     private final Context context;
     private final String SERVER_HOST = "https://forvo.com";
     private final String AUDIO_HTTP_HOST = "https://audio00.forvo.com";
+    private final String DEFAULT_FORVO_LANGUAGE = "ja";
 
     public Scraper(Context context) {
         this.context = context;
@@ -31,7 +32,7 @@ public class Scraper {
 
     public ArrayList<HashMap<String, String>> scrape(String word, String reading) throws IOException {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-        String forvoLanguage = preferences.getString("forvo_language", "ja");
+        String forvoLanguage = preferences.getString("forvo_language", DEFAULT_FORVO_LANGUAGE);
 
         ArrayList<HashMap<String, String>> audio_sources = scrapeWord(word, forvoLanguage);
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/APIHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/APIHandler.java
@@ -17,7 +17,7 @@ public class APIHandler {
 
     public APIHandler(IntegratedAPI integratedAPI, Context context) {
         ankiAPIRouting = new AnkiAPIRouting(integratedAPI);
-        forvoAPIRouting = new ForvoAPIRouting();
+        forvoAPIRouting = new ForvoAPIRouting(context);
         localAudioAPIRouting = new LocalAudioAPIRouting(context);
     }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/ForvoAPIRouting.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/ForvoAPIRouting.java
@@ -1,5 +1,6 @@
 package com.kamwithk.ankiconnectandroid.routing;
 
+import android.content.Context;
 import android.util.Log;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
@@ -19,8 +20,8 @@ import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 public class ForvoAPIRouting {
     private final Scraper scraper;
 
-    public ForvoAPIRouting() {
-        scraper = new Scraper();
+    public ForvoAPIRouting(Context context) {
+        scraper = new Scraper(context);
     }
 
 //    Term can also be named expression (older versions)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,14 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="forvo_language_entries">
+        <item>Arabic (ar)</item>
+        <item>German (de)</item>
+        <item>English (en)</item>
+        <item>Spanish (es)</item>
+        <item>French (fr)</item>
+        <item>Ancient Greek (grc)</item>
+        <item>Hungarian (hu)</item>
+        <item>Italian (it)</item>
         <item>Japanese (ja)</item>
-        <item>Chinese (zh)</item>
+        <item>Korean (ko)</item>
+        <item>Dutch (nl)</item>
+        <item>Polish (pl)</item>
+        <item>Portuguese (pt)</item>
+        <item>Russian (ru)</item>
+        <item>Swedish (sv)</item>
+        <item>Turkish (tr)</item>
+        <item>Tatar (tt)</item>
+        <item>Ukrainian (uk)</item>
         <item>Cantonese (yue)</item>
+        <item>Mandarin Chinese (zh)</item>
     </string-array>
 
     <string-array name="forvo_language_values">
+        <item>ar</item>
+        <item>de</item>
+        <item>en</item>
+        <item>es</item>
+        <item>fr</item>
+        <item>grc</item>
+        <item>hu</item>
+        <item>it</item>
         <item>ja</item>
-        <item>zh</item>
+        <item>ko</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>tt</item>
+        <item>uk</item>
         <item>yue</item>
+        <item>zh</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="forvo_language_entries">
+        <item>Japanese (ja)</item>
+        <item>Chinese (zh)</item>
+        <item>Cantonese (yue)</item>
+    </string-array>
+
+    <string-array name="forvo_language_values">
+        <item>ja</item>
+        <item>zh</item>
+        <item>yue</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,9 @@
     <string name="settings_permissions_header">Permissions</string>
     <string name="settings_overlay_permissions_summary">Allows Ankiconnect Android to open AnkiDroid\'s card browser.</string>
     <string name="settings_other_header">Other</string>
+    <string name="settings_forvo_language_title">Forvo language</string>
+    <string name="settings_forvo_language_summary">Sets the language to use for Forvo audio.</string>
+    <string name="settings_forvo_language_dialog_title">Select Language</string>
     <string name="get_dir_path_title">Print Local Audio Directory</string>
     <string name="get_dir_path_title_summary">Prints the expected directory path where the local audio is searched in.</string>
     <string name="dialog_notif_perm_info">This app uses a persistent notification to inform you that the server is running. Please enable notifications to see this.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -25,6 +25,15 @@
 
     <PreferenceCategory app:title="@string/settings_other_header">
 
+        <ListPreference
+            app:key="forvo_language"
+            app:title="@string/settings_forvo_language_title"
+            app:summary="@string/settings_forvo_language_summary"
+            android:dialogTitle="@string/settings_forvo_language_dialog_title"
+            android:defaultValue="ja"
+            android:entries="@array/forvo_language_entries"
+            android:entryValues="@array/forvo_language_values" />
+
         <Preference
             app:key="get_dir_path"
             app:title="@string/get_dir_path_title"


### PR DESCRIPTION
Adds options for Chinese or Cantonese when getting Forvo audio, asked for in #34 (well just Chinese but Cantonese was 2 more lines)  
Tested by following the steps here and then getting audio https://gist.github.com/shoui520/25460fd2e9fb194d3e5152fa2ce42ca2#audio

Screenshots of new setting: 
![image](https://github.com/KamWithK/AnkiconnectAndroid/assets/23278147/cf61300d-387a-432f-89e6-b0278ca5457a) ![image](https://github.com/KamWithK/AnkiconnectAndroid/assets/23278147/f30f07ea-df27-470c-865c-c87ac15338fe)
