### PR TITLE
Bump Anki-Android version to fix broken build (due to api-v1.1.0 being missing in jitpack.io)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
     implementation 'org.nanohttpd:nanohttpd-nanolets:2.3.1'
-    implementation 'com.github.ankidroid:Anki-Android:api-v1.1.0'
+    implementation 'com.github.ankidroid:Anki-Android:2.17alpha14'
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'androidx.preference:preference:1.2.0'
 


### PR DESCRIPTION
Current master branch doesn't build successfully anymore and you get this error:  
```
Configuration cache state could not be cached: field 'importDirs' from type 'com.android.build.gradle.tasks.AidlCompile': error writing value of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationFileCollection'
> Could not find Anki-Android-api-v1.1.0.aar (com.github.ankidroid:Anki-Android:api-v1.1.0).
  Searched in the following locations:
      https://jitpack.io/com/github/ankidroid/Anki-Android/api-v1.1.0/Anki-Android-api-v1.1.0.aar
```
Seems related to some version bumping in Anki-Android, saw an issue here: https://github.com/ankidroid/Anki-Android/issues/15052  
They recommended bumping to version `2.17alpha14` (and jidoudisho people did the same https://github.com/lrorpilla/jidoujisho/issues/301) so I've done that and the build works again
`2.14.3` is another option if want to stick to stable api versions