### PR TITLE
Allow requests that do not specify all fields

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -168,10 +168,7 @@ public class IntegratedAPI {
      * @throws Exception
      */
     public void addMedia(Map<String, String> noteValues, List<MediaRequest> mediaRequests) throws Exception {
-
-        // Store media and create a field: enclosed_filename map to avoid O(n^2) lookup later
-        Map<String, ArrayList<String>> field_to_files = new HashMap<>();
-        for (MediaRequest media: mediaRequests) {
+        for (MediaRequest media : mediaRequests) {
             // mediaAPI.storeMediaFile() doesn't store as the passed in filename, need to use the returned one
             Optional<byte[]> data = media.getData();
             Optional<String> url = media.getUrl();
@@ -195,21 +192,13 @@ public class IntegratedAPI {
                     break;
             }
 
-            for (String field: media.getFields()) {
-                if (!field_to_files.containsKey(field)) {
-                    field_to_files.put(field, new ArrayList<>());
-                }
-                field_to_files.get(field).add(enclosed_filename);
-            }
-        }
+            for (String field : media.getFields()) {
+                String existingValue = noteValues.get(field);
 
-        for (String fieldName : noteValues.keySet()) {
-            ArrayList<String> enclosed_media_filenames = field_to_files.get(fieldName);
-            if (enclosed_media_filenames != null) {
-                for (String enclosed_media_filename: enclosed_media_filenames) {
-                    // noteValues[fieldName] += enclosed_media_filename
-                    String fieldValue = noteValues.get(fieldName);
-                    noteValues.put(fieldName, fieldValue + enclosed_media_filename);
+                if (existingValue == null) {
+                    noteValues.put(field, enclosed_filename);
+                } else {
+                    noteValues.put(field, existingValue + enclosed_filename);
                 }
             }
         }

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/NoteAPI.java
@@ -43,9 +43,10 @@ public class NoteAPI {
         }
 
         // Get list in correct order
-        String[] fields = new String[data.size()];
-        for (int i = 0; i < data.size(); i++) {
-            fields[i] = data.get(allFieldNames[i]);
+        String[] fields = new String[allFieldNames.length];
+
+        for (int i = 0; i < allFieldNames.length; i++) {
+            fields[i] = data.getOrDefault(allFieldNames[i], "");
         }
 
         return api.addNote(model_id, deck_id, fields, tags);


### PR DESCRIPTION
- Some logic assumed that the client would specify a value for every field in the note type. This behavior is not present in the original AnkiConnect, and so this change is to make the behavior more similar to AnkiConnect and thus easier for AnkiConnect clients to transparently use this implementation of the API instead.
- Assumptions that a value is specified in params.note.fields for every field of the note type are removed:
  - When passing field values to the AddContentApi. An empty string is used as the default value for unspecified fields.
  - When modifying the field value map with media strings. If a field is specified for audio, that field is used even if an existing value for it doesn't exist under params.note.fields.