### PR TITLE
Fix updateNoteFields ArrayIndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -240,8 +240,12 @@ public class IntegratedAPI {
             if (newValue != null) {
                 // Update field to new value
                 cardFields.put(fieldName, newValue);
-            } else {
+                // Ankidroids `getFields` won't return empty fields that are at the end of the array
+                // so `originalFields` may potentially contain less fields than `modelFieldNames`
+            } else if (originalFields.length >= i + 1) {
                 cardFields.put(fieldName, originalFields[i]);
+            } else {
+                cardFields.put(fieldName, "");
             }
         }
 


### PR DESCRIPTION
https://github.com/KamWithK/AnkiconnectAndroid/pull/52 Bumped `Anki-Android` to `2.17alpha14` which effected the `getFields` call.

Ankidroid now removes the fields at the end of the array if they're empty, [see here](https://github.com/ankidroid/Anki-Android/blob/2f3d1b3294069088c7b6aafbfd42982a1199e3e7/api/src/main/java/com/ichi2/anki/api/Utils.kt#L41)

So `originalFields` would occasionally have less fields than `modelFieldNames` and it would throw a `ArrayIndexOutOfBoundsException`.
