### PR TITLE
Fix NullPointerException when adding new card using Local Audio

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java
@@ -24,7 +24,9 @@ import com.kamwithk.ankiconnectandroid.routing.localaudiosource.Shinmeikai8Audio
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -223,7 +225,16 @@ public class LocalAudioAPIRouting {
 
         EntriesDatabase db = getDB();
         AudioFileEntryDao audioFileEntryDao = db.audioFileEntryDao();
-        byte[] data = audioFileEntryDao.getData(path, source);
+
+        String pathDecoded;
+        try {
+            pathDecoded = URLDecoder.decode(path, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            pathDecoded = path;
+        }
+
+        byte[] data = audioFileEntryDao.getData(pathDecoded, source);
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
         String mimeType = null;

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java
@@ -226,12 +226,11 @@ public class LocalAudioAPIRouting {
         EntriesDatabase db = getDB();
         AudioFileEntryDao audioFileEntryDao = db.audioFileEntryDao();
 
-        String pathDecoded;
+        String pathDecoded = path;
         try {
-            pathDecoded = URLDecoder.decode(path, "UTF-8");
+            pathDecoded = URLDecoder.decode(pathDecoded, "UTF-8");
         }
-        catch (UnsupportedEncodingException e) {
-            pathDecoded = path;
+        catch (UnsupportedEncodingException ignored) {
         }
 
         byte[] data = audioFileEntryDao.getData(pathDecoded, source);


### PR DESCRIPTION
Fixes #71 

There are some devices, where the audio path is not fully decoded. This causes a NullPointerException [here](https://github.com/KamWithK/AnkiconnectAndroid/blob/a075592ab0b33a2ec3b849e6ac0483e1833f7c32/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/LocalAudioAPIRouting.java#L226). 

Instead of `audio/20170823111828.mp3` the path remains encoded as `audio%2F20170823111828.mp3` .

The issue doesn't seem to occur on every device:
- I wasn't able to reproduce it in Android Studio on an Android 15 instance, but on my physical Android e-reader.
- At least 3 people with different devices had this issue on the TMW Discord
- A few others mentioned they didn't have this issue.

While debugging, I did notice that percents are supposed to be decoded at some point, but it seems like the code never executes with `audio%2F20170823111828.mp3` as the input. Since this issue doesn't affect everyone, and since I was reluctant to make any deeper changes due to not being familiar with the full code, I instead opted to fix it by decoding the path at the problematic place. I have confirmed that this fixes the issue for OP of #71 .

If you want to try reproducing this: 

- Set up Yomitan with a single Dict, e.g. Jitendex
- Set up the Local Audio Server, and make sure it is the only audio source in Yomitan
- Completely disable internet access on device/emulator
- Try creating a new card

Since AnkiConnect fails to retrieve the audio files due to the path still being encoded, and since Yomitan is unable to fall back to an internet source, the audio field is left blank.
It would also be good to mention that this only happens when creating a new card, playing audio works fine without internet, and the path during execution of playback is also properly decoded.
If you'd like to, you can check out the e-reader thread in novel-discussion on TMW.