### PR TITLE
Support Access-Control-Request-Private-Network response header

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -22,6 +22,9 @@ import fi.iki.elonen.router.RouterNanoHTTPD;
 public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
 
     private APIHandler apiHandler = null;
+    private static final String PRIVATE_NETWORK_ACCESS_REQUEST = "Access-Control-Request-Private-Network";
+    private static final String PRIVATE_NETWORK_ACCESS_RESPONSE = "Access-Control-Allow-Private-Network";
+
 
     public RouteHandler() {
         super();
@@ -68,6 +71,12 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
         }
 
         NanoHTTPD.Response rep = apiHandler.chooseAPI(files.get("postData"), parameters);
+
+        // Include this header so that if a public origin is included in the whitelist, then browsers
+        // won't fail due to the private network access check
+        if (Boolean.parseBoolean(session.getHeaders().get(PRIVATE_NETWORK_ACCESS_REQUEST))) {
+            rep.addHeader(PRIVATE_NETWORK_ACCESS_RESPONSE, "true");
+        }
 
         addCorsHeaders(context, rep);
         return rep;


### PR DESCRIPTION
Should resolve #72 . Adds the Access-Control-Request-Private-Network response header if a request is received with a Access-Control-Request-Private-Network header.

Note that I am currently unable to test the changes as is; I haven't been able to reproduce this issue on my android device with Kiwi Browser, and asbplayer isn't on the Edge addon store to my knowledge. 

I tested the response header by removing the conditional check, so that the app would always add the Access-Control-Request-Private-Network to the response:

![Screenshot_20250407_072912_Kiwi Browser](https://github.com/user-attachments/assets/f32ce1ff-975f-4979-b81a-8fa75a18c186)
