### PR TITLE
Fix: Accept numeric version field in AnkiConnect API requests

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/Parser.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/Parser.java
@@ -34,12 +34,25 @@ public static JsonObject parse(String raw_data) {
         return data.get("action").getAsString();
     }
 
-    public static int get_version(JsonObject data, int fallback) {
-        if (data.has("version")) {
-            return data.get("version").getAsInt();
+public static int get_version(JsonObject data, int fallback) {
+    if (data.has("version")) {
+        JsonElement versionElement = data.get("version");
+        // Handle both string and numeric version fields
+        if (versionElement.isJsonPrimitive()) {
+            com.google.gson.JsonPrimitive primitive = versionElement.getAsJsonPrimitive();
+            if (primitive.isNumber()) {
+                return primitive.getAsInt();
+            } else if (primitive.isString()) {
+                try {
+                    return Integer.parseInt(primitive.getAsString());
+                } catch (NumberFormatException e) {
+                    return fallback;
+                }
+            }
         }
-        return fallback;
     }
+    return fallback;
+}
 
     public static String getDeckName(JsonObject raw_data) {
         return raw_data.get("params").getAsJsonObject().get("note").getAsJsonObject().get("deckName").getAsString();

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/Parser.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/Parser.java
@@ -21,9 +21,14 @@ public class Parser {
     public static Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
     public static Gson gsonNoSerialize = new GsonBuilder().setPrettyPrinting().create();
 
-    public static JsonObject parse(String raw_data) {
-        return JsonParser.parseString(raw_data).getAsJsonObject();
-    }
+public static JsonObject parse(String raw_data) {
+    // Use a more lenient parser that accepts both numeric and string version fields
+    com.google.gson.stream.JsonReader reader = new com.google.gson.stream.JsonReader(
+        new java.io.StringReader(raw_data)
+    );
+    reader.setLenient(true);
+    return JsonParser.parseReader(reader).getAsJsonObject();
+}
 
     public static String get_action(JsonObject data) {
         return data.get("action").getAsString();


### PR DESCRIPTION
Fixes [KOReader Anki plugin](https://github.com/Ajatt-Tools/anki.koplugin) compatibility by accepting numeric `version` fields in API requests.

## Problem
KOReader sends `{"version":6,"action":"requestPermission"}` with version as a number (per the official AnkiConnect API spec), but AnkiConnect Android was rejecting this with a MalformedJsonException at column 14 (immediately after the numeric 6).

## Solution
1. Made the JSON parser lenient to accept both numeric and string version fields
2. Updated `get_version()` to explicitly handle both number and string types for the version field

## Testing
- The official AnkiConnect API spec uses version as a number
- This maintains backward compatibility with clients that send version as a string (like Yomitan)
- Fixes #[89]

Related issue: https://github.com/KamWithK/AnkiconnectAndroid/issues/89