### PR TITLE
Rework canAddNotes and canAddNotesWithErrorDetails to more closely match AnkiConnect desktop

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -34,8 +34,8 @@ public class IntegratedAPI {
 
     //From anki-connect repo
     private static final String CAN_ADD_ERROR_DUPLICATE = "cannot create note because it is a duplicate";
-    private static final String CAN_ADD_ERROR_EMPTY_MODEL = "model was not found: {}";
-    private static final String CAN_ADD_ERROR_EMPTY_DECK_NAME = "cannot create note because it is empty";
+    private static final String CAN_ADD_ERROR_EMPTY_MODEL = "model was not found: ";
+    private static final String CAN_ADD_ERROR_EMPTY_DECK_NAME = "deck was not found: ";
     private static final String CAN_ADD_ERROR_EMPTY = "cannot create note because it is empty";
     private static final String CAN_ADD_ERROR_UNKNOWN = "cannot create note for unknown reason";
     public IntegratedAPI(Context context) {
@@ -73,7 +73,7 @@ public class IntegratedAPI {
         }
     }
 
-    private CanAddWithError canAddNodeCheck(NoteRequest note) throws Exception {
+    private CanAddWithError canAddNoteCheck(NoteRequest note) throws Exception {
         final String[] NOTE_PROJECTION = {
                 FlashCardsContract.Note._ID,
                 FlashCardsContract.Note.CSUM
@@ -106,7 +106,7 @@ public class IntegratedAPI {
         }
 
         // Ensure not has valid field name and field value
-        // If users have not set up Yomitan for any of the default formats, these values will be null
+        // If users have not set up any of the default card formats in Yomitan, these values will be null
         if (note.getFieldName() == null && note.getFieldValue() == null) {
             return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);
         }
@@ -136,7 +136,7 @@ public class IntegratedAPI {
 
         selectionQuery.append(String.format(
                 Locale.US,
-                "%s = %s",
+                "%s = %d",
                 FlashCardsContract.Note.CSUM,
                 checksum
         ));
@@ -166,7 +166,7 @@ public class IntegratedAPI {
 
     private boolean canAddNote(NoteRequest note) {
         try {
-            return canAddNodeCheck(note).isCanAdd();
+            return canAddNoteCheck(note).isCanAdd();
         } catch (Exception e) {
             return false;
         }
@@ -250,7 +250,7 @@ public class IntegratedAPI {
 
     private CanAddWithError canAddNoteWithErrorDetail(NoteRequest note) {
         try {
-            return canAddNodeCheck(note);
+            return canAddNoteCheck(note);
         } catch (Exception e) {
             return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
         }

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -105,7 +105,7 @@ public class IntegratedAPI {
             }
         }
 
-        // Ensure not has valid field name and field value
+        // Ensure note has valid field name and field value
         // If users have not set up any of the default card formats in Yomitan, these values will be null
         if (note.getFieldName() == null && note.getFieldValue() == null) {
             return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -99,7 +99,7 @@ public class IntegratedAPI {
         Long modelId = null;
         boolean duplicateCheck = false;
         CanAddWithError canAddWithError;
-        List<Long> deckIds = new ArrayList<>();
+        Set<Long> deckIds = new HashSet<>();
         private NoteInfo(NoteRequest note) {
             this.note = note;
         }
@@ -169,20 +169,28 @@ public class IntegratedAPI {
             return;
         }
 
+        boolean isDeckScope = noteInfo.note.getOptions().getDuplicateScope().equals("deck");
+        boolean checkAllModels = noteInfo.note.getOptions().isCheckAllModels();
         boolean hasDuplicate = false;
         for (DuplicateNote duplicate : duplicates) {
             // filter by model here instead of in query
-            boolean checkAllModels = noteInfo.note.getOptions().isCheckAllModels();
             if (!checkAllModels && noteInfo.modelId != duplicate.mid) {
                 continue;
             }
 
-            hasDuplicate = true;
+            if (isDeckScope) {
+                if (isNoteInDeck(duplicate.id, noteInfo.deckIds)) {
+                    hasDuplicate = true;
+                    break;
+                }
+            }
+            else {
+                hasDuplicate = true;
+                break;
+            }
         }
 
         noteInfo.canAddWithError = hasDuplicate ? new CanAddWithError(false, CAN_ADD_ERROR_DUPLICATE) : new CanAddWithError(true, null);
-
-        // todo: duplicateScope
     }
 
     private Map<Long, Set<DuplicateNote>> getDuplicateNotes(Set<Long> unprocessedChecksums) {
@@ -202,7 +210,7 @@ public class IntegratedAPI {
 
         // as a checksum can have multiple notes this has to be a map
         Map<Long, Set<DuplicateNote>> duplicateNotes = new HashMap<>();
-        // this is basically findChecksumsInQuery, we collect all duplicate checksums for every checksum
+        // this is basically findChecksumsInQuery, we collect all duplicate notes for each checksum
         try (Cursor cursor = context.getContentResolver().query(
                 FlashCardsContract.Note.CONTENT_URI_V2,
                 NOTE_PROJECTION,
@@ -283,6 +291,35 @@ public class IntegratedAPI {
         return result;
     }
 
+    private boolean isNoteInDeck(long noteId, Set<Long> deckIds) {
+        // Need to search for all cards with the same note ID, and see if they exist in one of the decks.
+        final String[] CARD_PROJECTION = {FlashCardsContract.Card.DECK_ID};
+
+        Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+        Uri cardUri = Uri.withAppendedPath(noteUri, "cards");
+        Cursor cardCursor = context.getContentResolver().query(
+                cardUri,
+                CARD_PROJECTION,
+                null,
+                null,
+                null
+        );
+
+        if(cardCursor != null) {
+            try (cardCursor) {
+                while(cardCursor.moveToNext()) {
+                    int didIdx = cardCursor.getColumnIndexOrThrow(FlashCardsContract.Card.DECK_ID);
+                    long did = cardCursor.getLong(didIdx);
+
+                    if (deckIds.contains(did)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
     /**
      * Add flashcards to AnkiDroid through instant add API
      * @param data Map of (field name, field value) pairs

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -73,163 +73,6 @@ public class IntegratedAPI {
         }
     }
 
-    private CanAddWithError canAddNoteCheck(NoteRequest note) throws Exception {
-        final String[] NOTE_PROJECTION = {
-                FlashCardsContract.Note._ID,
-                FlashCardsContract.Note.CSUM
-        };
-
-        NoteRequest.NoteOptions noteOptions = note.getOptions();
-        String modelName = note.getModelName();
-
-        if (modelName == null || modelName.isEmpty()) {
-            return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL);
-        }
-
-        HashSet<Long> deckIds = new HashSet<>();
-        Map<String, Long> deckNamesToIds = deckAPI.deckNamesAndIds();
-        String deckName = noteOptions.getDeckName();
-
-        if (deckName == null) {
-            // Deck, not root
-            deckName = note.getDeckName();
-            if (deckName == null || deckName.isEmpty()) {
-                return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_DECK_NAME);
-            }
-            deckIds.add(deckNamesToIds.get(deckName));
-        } else {
-            for (String name : deckNamesToIds.keySet()) {
-                if (name.contains(deckName)) {
-                    deckIds.add(deckNamesToIds.get(name));
-                }
-            }
-        }
-
-        // Ensure note has valid field name and field value
-        // If users have not set up any of the default card formats in Yomitan, these values will be null
-        if (note.getFieldName() == null && note.getFieldValue() == null) {
-            return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);
-        }
-
-        long checksum = Utility.getFieldChecksum(note.getFieldValue());
-
-        // If duplicates are allowed, just need to see if they are valid notes (checksum != 0)
-        if (noteOptions.isAllowDuplicate()) {
-            if (checksum == 0) {
-                return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
-            }
-            return new CanAddWithError(true, null);
-        }
-
-        Map<String, Long> modelNameToId = modelAPI.modelNamesAndIds(0);
-        Long modelId = modelNameToId.get(modelName);
-
-        StringBuilder selectionQuery = new StringBuilder();
-        if (!noteOptions.isCheckAllModels()) {
-            selectionQuery.append(String.format(
-                    Locale.US,
-                    "%s = %d and ",
-                    FlashCardsContract.Note.MID,
-                    modelId
-            ));
-        }
-
-        selectionQuery.append(String.format(
-                Locale.US,
-                "%s = %d",
-                FlashCardsContract.Note.CSUM,
-                checksum
-        ));
-
-        try (Cursor cursor = context.getContentResolver().query(
-                FlashCardsContract.Note.CONTENT_URI_V2,
-                NOTE_PROJECTION,
-                selectionQuery.toString(),
-                null,
-                null
-        )) {
-            if (cursor != null && cursor.getCount() != 0) {
-                LinkedHashSet<Long> queryChecksums = findChecksumsInQuery(
-                        cursor,
-                        noteOptions.getDuplicateScope().equals("deck"),
-                        deckIds
-                );
-                if (queryChecksums.contains(checksum)) {
-                    return new CanAddWithError(false, CAN_ADD_ERROR_DUPLICATE);
-                }
-            }
-            return new CanAddWithError(true, null);
-        } catch (Exception e) {
-            return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
-        }
-    }
-
-    private boolean canAddNote(NoteRequest note) {
-        try {
-            return canAddNoteCheck(note).isCanAdd();
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    public List<Boolean> canAddNotes(ArrayList<NoteRequest> notesToTest) {
-        return notesToTest.stream().map(this::canAddNote).collect(Collectors.toList());
-    }
-
-    private LinkedHashSet<Long> findChecksumsInQuery(Cursor cursor, boolean isDuplicateScopeDeck, Set<Long> deckIds) {
-        LinkedHashSet<Long> queryChecksums = new LinkedHashSet<>();
-
-        try (cursor) {
-            while (cursor.moveToNext()) {
-                // Build list of CSUM (queryChecksums)
-                // If an entry in queryChecksums is in checksums, then we have a duplicate
-                // If scope is "deck", these duplicates need to be checked again for the deck
-                int idIdx = cursor.getColumnIndexOrThrow(FlashCardsContract.Note._ID);
-                int csumIdx = cursor.getColumnIndexOrThrow(FlashCardsContract.Note.CSUM);
-
-                long queryNid = cursor.getLong(idIdx);
-                long queryCsum = cursor.getLong(csumIdx);
-
-                // If duplicate scope is "deck", need an additional query
-                if (!isDuplicateScopeDeck || isNoteInDeck(queryNid, deckIds)) {
-                    queryChecksums.add(queryCsum);
-                }
-            }
-        }
-
-        return queryChecksums;
-    }
-
-    private boolean isNoteInDeck(long noteId, Set<Long> deckIds) {
-        // Need to search for all cards with the same note ID, and see if they exist in one of the decks.
-        final String[] CARD_PROJECTION = {FlashCardsContract.Card.DECK_ID};
-
-        Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
-        Uri cardUri = Uri.withAppendedPath(noteUri, "cards");
-        Cursor cardCursor = context.getContentResolver().query(
-                cardUri,
-                CARD_PROJECTION,
-                null,
-                null,
-                null
-        );
-
-        if(cardCursor != null) {
-            try (cardCursor) {
-                while(cardCursor.moveToNext()) {
-                    int didIdx = cardCursor.getColumnIndexOrThrow(FlashCardsContract.Card.DECK_ID);
-                    long did = cardCursor.getLong(didIdx);
-
-                    if (deckIds.contains(did)) {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
     public static class CanAddWithError {
         private final boolean canAdd;
         private final String error;
@@ -248,16 +91,178 @@ public class IntegratedAPI {
         }
     }
 
-    private CanAddWithError canAddNoteWithErrorDetail(NoteRequest note) {
-        try {
-            return canAddNoteCheck(note);
-        } catch (Exception e) {
-            return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
+    private static class NoteInfo {
+        final NoteRequest note;
+        Long checksum = null;
+        Long modelId = null;
+        boolean needsProcessing = false;
+        CanAddWithError canAddWithError;
+        List<Long> deckIds = new ArrayList<>();
+        private NoteInfo(NoteRequest note) {
+            this.note = note;
         }
     }
 
-    public List<CanAddWithError> canAddNotesWithErrorDetail(ArrayList<NoteRequest> notesToTest) {
-        return notesToTest.stream().map(this::canAddNoteWithErrorDetail).collect(Collectors.toList());
+    private static class DuplicateNote {
+        long id;
+        long mid;
+
+        private DuplicateNote(long id, long mid) {
+            this.id = id;
+            this.mid = mid;
+        }
+    }
+
+    public List<Boolean> canAddNotes(List<NoteRequest> notes) {
+        return canAddNotesWithErrorDetail(notes).stream().map(CanAddWithError::isCanAdd).collect(Collectors.toList());
+    }
+
+    public List<CanAddWithError> canAddNotesWithErrorDetail(List<NoteRequest> notes) {
+        if (notes == null || notes.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        Map<String, Long> deckNamesToIds;
+        Map<String, Long> modelNameToId;
+        try {
+            deckNamesToIds = deckAPI.deckNamesAndIds();
+            modelNameToId = modelAPI.modelNamesAndIds(0);
+        } catch (Exception e) {
+            ArrayList<CanAddWithError> err = new ArrayList<>();
+            notes.forEach(n -> err.add(new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN)));
+            return err;
+        }
+
+        List<NoteInfo> noteInfos = new ArrayList<>(notes.size());
+        Set<Long> unprocessedChecksums = new HashSet<>();
+        for (NoteRequest note : notes) {
+            NoteInfo noteInfo = new NoteInfo(note);
+            noteInfos.add(noteInfo);
+            NoteRequest.NoteOptions noteOptions = note.getOptions();
+
+            String modelName = note.getModelName();
+            if (modelName == null || modelName.isEmpty()) {
+                noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL);
+                continue;
+            }
+
+            noteInfo.modelId = modelNameToId.get(modelName);
+            if (noteInfo.modelId == null) {
+                noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL + modelName);
+                continue;
+            }
+
+            String deckName = noteOptions.getDeckName();
+            if (deckName == null) {
+                // Deck, not root
+                deckName = note.getDeckName();
+                if (deckName == null || deckName.isEmpty()) {
+                    noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_DECK_NAME);
+                    continue;
+                }
+                noteInfo.deckIds.add(deckNamesToIds.get(deckName));
+            }
+            else {
+                for (String name : deckNamesToIds.keySet()) {
+                    if (name.contains(deckName)) {
+                        noteInfo.deckIds.add(deckNamesToIds.get(name));
+                    }
+                }
+            }
+
+            if (note.getFieldName() == null && note.getFieldValue() == null) {
+                noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);
+                continue;
+            }
+
+            noteInfo.checksum = Utility.getFieldChecksum(note.getFieldValue());
+
+            // If duplicates are allowed, just need to see if they are valid notes (checksum != 0)
+            if (noteOptions.isAllowDuplicate()) {
+                noteInfo.canAddWithError = (noteInfo.checksum == 0) ?
+                        new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN) : new CanAddWithError(true, null);
+                continue;
+            }
+
+            // Remaining notes need duplicate checking
+            noteInfo.needsProcessing = true;
+            unprocessedChecksums.add(noteInfo.checksum);
+        }
+
+        if (unprocessedChecksums.isEmpty()) {
+            return noteInfos.stream().map(n -> n.canAddWithError).collect(Collectors.toList());
+        }
+
+        final String[] NOTE_PROJECTION = {
+                FlashCardsContract.Note._ID,
+                FlashCardsContract.Note.CSUM,
+                FlashCardsContract.Note.MID
+        };
+
+        String checksums = TextUtils.join(",", unprocessedChecksums);
+        String selection = String.format(
+                Locale.US,
+                "%s in (%s)",
+                FlashCardsContract.Note.CSUM,
+                checksums
+        );
+
+        // as a checksum can have multiple notes this has to be a map
+        Map<Long, Set<DuplicateNote>> duplicateNotes = new HashMap<>();
+        // this is basically findChecksumsInQuery, we collect all duplicate checksums for every checksum
+        try (Cursor cursor = context.getContentResolver().query(
+                FlashCardsContract.Note.CONTENT_URI_V2,
+                NOTE_PROJECTION,
+                selection,
+                null,
+                null
+        )) {
+            if (cursor != null) {
+                int idIdx = cursor.getColumnIndexOrThrow(FlashCardsContract.Note._ID);
+                int midIdx = cursor.getColumnIndexOrThrow(FlashCardsContract.Note.MID);
+                int csumIdx = cursor.getColumnIndexOrThrow(FlashCardsContract.Note.CSUM);
+
+                while (cursor.moveToNext()) {
+                    long id = cursor.getLong(idIdx);
+                    long mid = cursor.getLong(midIdx);
+                    long csum = cursor.getLong(csumIdx);
+
+                    Set<DuplicateNote> set = duplicateNotes.computeIfAbsent(csum, k -> new HashSet<>());
+                    set.add(new DuplicateNote(id, mid));
+                }
+            }
+        } catch (Exception e) {
+            // todo: cancel batch?
+        }
+
+        for (NoteInfo noteInfo : noteInfos) {
+            if (!noteInfo.needsProcessing) {
+                continue;
+            }
+
+            Set<DuplicateNote> duplicates = duplicateNotes.get(noteInfo.checksum);
+            if (duplicates == null) {
+                noteInfo.canAddWithError = new CanAddWithError(true, null);
+                continue;
+            }
+
+            boolean hasDuplicate = false;
+            for (DuplicateNote duplicate : duplicates) {
+                // filter by model here instead of in query
+                boolean checkAllModels = noteInfo.note.getOptions().isCheckAllModels();
+                if (!checkAllModels && noteInfo.modelId != duplicate.mid) {
+                    continue;
+                }
+
+                hasDuplicate = true;
+            }
+
+            noteInfo.canAddWithError = hasDuplicate ? new CanAddWithError(false, CAN_ADD_ERROR_DUPLICATE) : new CanAddWithError(true, null);
+
+            // todo: duplicateScope
+        }
+
+        return noteInfos.stream().map(ninfo -> ninfo.canAddWithError).collect(Collectors.toList());
     }
 
     /**

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -239,7 +239,8 @@ public class IntegratedAPI {
                 }
             }
         } catch (Exception e) {
-            // todo: cancel batch?
+            // assume no duplicates if query fails
+            return Collections.emptyMap();
         }
         return duplicateNotes;
     }

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -10,6 +10,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -95,7 +97,7 @@ public class IntegratedAPI {
         final NoteRequest note;
         Long checksum = null;
         Long modelId = null;
-        boolean needsProcessing = false;
+        boolean duplicateCheck = false;
         CanAddWithError canAddWithError;
         List<Long> deckIds = new ArrayList<>();
         private NoteInfo(NoteRequest note) {
@@ -134,65 +136,56 @@ public class IntegratedAPI {
         }
 
         List<NoteInfo> noteInfos = new ArrayList<>(notes.size());
-        Set<Long> unprocessedChecksums = new HashSet<>();
+        Set<Long> checksums = new HashSet<>();
         for (NoteRequest note : notes) {
-            NoteInfo noteInfo = new NoteInfo(note);
+            NoteInfo noteInfo = validateNoteRequest(note, modelNameToId, deckNamesToIds);
             noteInfos.add(noteInfo);
-            NoteRequest.NoteOptions noteOptions = note.getOptions();
-
-            String modelName = note.getModelName();
-            if (modelName == null || modelName.isEmpty()) {
-                noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL);
-                continue;
+            if (noteInfo.duplicateCheck) {
+                checksums.add(noteInfo.checksum);
             }
-
-            noteInfo.modelId = modelNameToId.get(modelName);
-            if (noteInfo.modelId == null) {
-                noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL + modelName);
-                continue;
-            }
-
-            String deckName = noteOptions.getDeckName();
-            if (deckName == null) {
-                // Deck, not root
-                deckName = note.getDeckName();
-                if (deckName == null || deckName.isEmpty()) {
-                    noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_DECK_NAME);
-                    continue;
-                }
-                noteInfo.deckIds.add(deckNamesToIds.get(deckName));
-            }
-            else {
-                for (String name : deckNamesToIds.keySet()) {
-                    if (name.contains(deckName)) {
-                        noteInfo.deckIds.add(deckNamesToIds.get(name));
-                    }
-                }
-            }
-
-            if (note.getFieldName() == null && note.getFieldValue() == null) {
-                noteInfo.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);
-                continue;
-            }
-
-            noteInfo.checksum = Utility.getFieldChecksum(note.getFieldValue());
-
-            // If duplicates are allowed, just need to see if they are valid notes (checksum != 0)
-            if (noteOptions.isAllowDuplicate()) {
-                noteInfo.canAddWithError = (noteInfo.checksum == 0) ?
-                        new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN) : new CanAddWithError(true, null);
-                continue;
-            }
-
-            // Remaining notes need duplicate checking
-            noteInfo.needsProcessing = true;
-            unprocessedChecksums.add(noteInfo.checksum);
         }
 
-        if (unprocessedChecksums.isEmpty()) {
+        if (checksums.isEmpty()) {
             return noteInfos.stream().map(n -> n.canAddWithError).collect(Collectors.toList());
         }
 
+        Map<Long, Set<DuplicateNote>> duplicateNotes = getDuplicateNotes(checksums);
+
+        for (NoteInfo noteInfo : noteInfos) {
+            if (!noteInfo.duplicateCheck) {
+                continue;
+            }
+
+            duplicateCheck(noteInfo, duplicateNotes);
+        }
+
+        return noteInfos.stream().map(ninfo -> ninfo.canAddWithError).collect(Collectors.toList());
+    }
+
+    private void duplicateCheck(NoteInfo noteInfo, Map<Long, Set<DuplicateNote>> duplicateNotes) {
+        Set<DuplicateNote> duplicates = duplicateNotes.get(noteInfo.checksum);
+        if (duplicates == null) {
+            noteInfo.canAddWithError = new CanAddWithError(true, null);
+            return;
+        }
+
+        boolean hasDuplicate = false;
+        for (DuplicateNote duplicate : duplicates) {
+            // filter by model here instead of in query
+            boolean checkAllModels = noteInfo.note.getOptions().isCheckAllModels();
+            if (!checkAllModels && noteInfo.modelId != duplicate.mid) {
+                continue;
+            }
+
+            hasDuplicate = true;
+        }
+
+        noteInfo.canAddWithError = hasDuplicate ? new CanAddWithError(false, CAN_ADD_ERROR_DUPLICATE) : new CanAddWithError(true, null);
+
+        // todo: duplicateScope
+    }
+
+    private Map<Long, Set<DuplicateNote>> getDuplicateNotes(Set<Long> unprocessedChecksums) {
         final String[] NOTE_PROJECTION = {
                 FlashCardsContract.Note._ID,
                 FlashCardsContract.Note.CSUM,
@@ -234,35 +227,60 @@ public class IntegratedAPI {
         } catch (Exception e) {
             // todo: cancel batch?
         }
+        return duplicateNotes;
+    }
 
-        for (NoteInfo noteInfo : noteInfos) {
-            if (!noteInfo.needsProcessing) {
-                continue;
-            }
+    private NoteInfo validateNoteRequest(NoteRequest note, Map<String, Long> modelNameToId, Map<String, Long> deckNamesToIds) {
+        NoteInfo result = new NoteInfo(note);
+        NoteRequest.NoteOptions noteOptions = note.getOptions();
 
-            Set<DuplicateNote> duplicates = duplicateNotes.get(noteInfo.checksum);
-            if (duplicates == null) {
-                noteInfo.canAddWithError = new CanAddWithError(true, null);
-                continue;
-            }
-
-            boolean hasDuplicate = false;
-            for (DuplicateNote duplicate : duplicates) {
-                // filter by model here instead of in query
-                boolean checkAllModels = noteInfo.note.getOptions().isCheckAllModels();
-                if (!checkAllModels && noteInfo.modelId != duplicate.mid) {
-                    continue;
-                }
-
-                hasDuplicate = true;
-            }
-
-            noteInfo.canAddWithError = hasDuplicate ? new CanAddWithError(false, CAN_ADD_ERROR_DUPLICATE) : new CanAddWithError(true, null);
-
-            // todo: duplicateScope
+        String modelName = note.getModelName();
+        if (modelName == null || modelName.isEmpty()) {
+            result.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL);
+            return result;
         }
 
-        return noteInfos.stream().map(ninfo -> ninfo.canAddWithError).collect(Collectors.toList());
+        result.modelId = modelNameToId.get(modelName);
+        if (result.modelId == null) {
+            result.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL + modelName);
+            return result;
+        }
+
+        String deckName = noteOptions.getDeckName();
+        if (deckName == null) {
+            // Deck, not root
+            deckName = note.getDeckName();
+            if (deckName == null || deckName.isEmpty()) {
+                result.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_DECK_NAME);
+                return result;
+            }
+            result.deckIds.add(deckNamesToIds.get(deckName));
+        }
+        else {
+            for (String name : deckNamesToIds.keySet()) {
+                if (name.contains(deckName)) {
+                    result.deckIds.add(deckNamesToIds.get(name));
+                }
+            }
+        }
+
+        if (note.getFieldName() == null && note.getFieldValue() == null) {
+            result.canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);
+            return result;
+        }
+
+        result.checksum = Utility.getFieldChecksum(note.getFieldValue());
+
+        // If duplicates are allowed, just need to see if they are valid notes (checksum != 0)
+        if (noteOptions.isAllowDuplicate()) {
+            result.canAddWithError = (result.checksum == 0) ?
+                    new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN) : new CanAddWithError(true, null);
+            return result;
+        }
+
+        // Note needs duplicate checking
+        result.duplicateCheck = true;
+        return result;
     }
 
     /**

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -116,7 +116,9 @@ public class IntegratedAPI {
     }
 
     public List<Boolean> canAddNotes(List<NoteRequest> notes) {
-        return canAddNotesWithErrorDetail(notes).stream().map(CanAddWithError::isCanAdd).collect(Collectors.toList());
+        return canAddNotesWithErrorDetail(notes).stream()
+                .map(CanAddWithError::isCanAdd)
+                .collect(Collectors.toList());
     }
 
     public List<CanAddWithError> canAddNotesWithErrorDetail(List<NoteRequest> notes) {
@@ -130,9 +132,9 @@ public class IntegratedAPI {
             deckNamesToIds = deckAPI.deckNamesAndIds();
             modelNameToId = modelAPI.modelNamesAndIds(0);
         } catch (Exception e) {
-            ArrayList<CanAddWithError> err = new ArrayList<>();
-            notes.forEach(n -> err.add(new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN)));
-            return err;
+            return notes.stream()
+                    .map(n -> new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN))
+                    .collect(Collectors.toList());
         }
 
         List<NoteInfo> noteInfos = new ArrayList<>(notes.size());
@@ -146,7 +148,9 @@ public class IntegratedAPI {
         }
 
         if (checksums.isEmpty()) {
-            return noteInfos.stream().map(n -> n.canAddWithError).collect(Collectors.toList());
+            return noteInfos.stream()
+                    .map(n -> n.canAddWithError)
+                    .collect(Collectors.toList());
         }
 
         Map<Long, Set<DuplicateNote>> duplicateNotes = getDuplicateNotes(checksums);
@@ -159,7 +163,9 @@ public class IntegratedAPI {
             duplicateCheck(noteInfo, duplicateNotes);
         }
 
-        return noteInfos.stream().map(ninfo -> ninfo.canAddWithError).collect(Collectors.toList());
+        return noteInfos.stream()
+                .map(ninfo -> ninfo.canAddWithError)
+                .collect(Collectors.toList());
     }
 
     private void duplicateCheck(NoteInfo noteInfo, Map<Long, Set<DuplicateNote>> duplicateNotes) {

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/ankidroid_api/IntegratedAPI.java
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.ichi2.anki.api.AddContentApi.READ_WRITE_PERMISSION;
 
@@ -32,7 +33,11 @@ public class IntegratedAPI {
     private final AddContentApi api; // TODO: Combine all API classes???
 
     //From anki-connect repo
-    private static final String CAN_ADD_ERROR_REASON = "cannot create note because it is a duplicate";
+    private static final String CAN_ADD_ERROR_DUPLICATE = "cannot create note because it is a duplicate";
+    private static final String CAN_ADD_ERROR_EMPTY_MODEL = "model was not found: {}";
+    private static final String CAN_ADD_ERROR_EMPTY_DECK_NAME = "cannot create note because it is empty";
+    private static final String CAN_ADD_ERROR_EMPTY = "cannot create note because it is empty";
+    private static final String CAN_ADD_ERROR_UNKNOWN = "cannot create note for unknown reason";
     public IntegratedAPI(Context context) {
         this.context = context;
 
@@ -68,28 +73,31 @@ public class IntegratedAPI {
         }
     }
 
-    public ArrayList<Boolean> canAddNotes(ArrayList<NoteRequest> notesToTest) throws Exception {
-        final String[] NOTE_PROJECTION = {FlashCardsContract.Note._ID, FlashCardsContract.Note.CSUM};
+    private CanAddWithError canAddNodeCheck(NoteRequest note) throws Exception {
+        final String[] NOTE_PROJECTION = {
+                FlashCardsContract.Note._ID,
+                FlashCardsContract.Note.CSUM
+        };
 
-        if(notesToTest.isEmpty()) {
-            return new ArrayList<>();
+        NoteRequest.NoteOptions noteOptions = note.getOptions();
+        String modelName = note.getModelName();
+
+        if (modelName == null || modelName.isEmpty()) {
+            return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_MODEL);
         }
 
-        ArrayList<Long> checksums = new ArrayList<>(notesToTest.size());
-        ArrayList<Boolean> canAddNote = new ArrayList<>(notesToTest.size());
-        NoteRequest.NoteOptions noteOptions = notesToTest.get(0).getOptions();
-
-        // If duplicate scope is "deck" or "deck root", we need to get extra information to figure out if DID matches.
-        // If duplicate scope is "deck root" we need to include children, noteOptions.getDeckName() will not be null
         HashSet<Long> deckIds = new HashSet<>();
         Map<String, Long> deckNamesToIds = deckAPI.deckNamesAndIds();
         String deckName = noteOptions.getDeckName();
-        if(deckName == null) {
+
+        if (deckName == null) {
             // Deck, not root
-            deckName = notesToTest.get(0).getDeckName();
+            deckName = note.getDeckName();
+            if (deckName == null || deckName.isEmpty()) {
+                return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY_DECK_NAME);
+            }
             deckIds.add(deckNamesToIds.get(deckName));
-        }
-        else {
+        } else {
             for (String name : deckNamesToIds.keySet()) {
                 if (name.contains(deckName)) {
                     deckIds.add(deckNamesToIds.get(name));
@@ -97,67 +105,75 @@ public class IntegratedAPI {
             }
         }
 
-        for (NoteRequest note : notesToTest) {
-            String key = note.getFieldValue();
-            checksums.add(Utility.getFieldChecksum(key));
+        // Ensure not has valid field name and field value
+        // If users have not set up Yomitan for any of the default formats, these values will be null
+        if (note.getFieldName() == null && note.getFieldValue() == null) {
+            return new CanAddWithError(false, CAN_ADD_ERROR_EMPTY);
         }
+
+        long checksum = Utility.getFieldChecksum(note.getFieldValue());
 
         // If duplicates are allowed, just need to see if they are valid notes (checksum != 0)
         if (noteOptions.isAllowDuplicate()) {
-            for (long checksum: checksums) {
-                canAddNote.add(checksum != 0);
+            if (checksum == 0) {
+                return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
             }
-            return canAddNote;
+            return new CanAddWithError(true, null);
         }
-
-        // Grabbing the note options and model for the first note and assuming the rest are the same.
-        // This is true for yomitan but might not be for other applications.
-        String modelName = notesToTest.get(0).getModelName();
 
         Map<String, Long> modelNameToId = modelAPI.modelNamesAndIds(0);
         Long modelId = modelNameToId.get(modelName);
 
-        String selectionQuery = "";
+        StringBuilder selectionQuery = new StringBuilder();
         if (!noteOptions.isCheckAllModels()) {
-            selectionQuery = String.format(
+            selectionQuery.append(String.format(
                     Locale.US,
-                    "%s=%d and ",
+                    "%s = %d and ",
                     FlashCardsContract.Note.MID,
                     modelId
-            );
+            ));
         }
-        selectionQuery = selectionQuery + String.format(
-                Locale.US,
-                "%s in (%s)",
-                FlashCardsContract.Note.CSUM,
-                TextUtils.join(",", checksums)
-        );
 
-        final Cursor cursor = context.getContentResolver().query(
+        selectionQuery.append(String.format(
+                Locale.US,
+                "%s = %s",
+                FlashCardsContract.Note.CSUM,
+                checksum
+        ));
+
+        try (Cursor cursor = context.getContentResolver().query(
                 FlashCardsContract.Note.CONTENT_URI_V2,
                 NOTE_PROJECTION,
-                selectionQuery,
+                selectionQuery.toString(),
                 null,
                 null
-        );
-
-        if (cursor == null || cursor.getCount() == 0) {
-            for (int i = 0; i < notesToTest.size(); i++) {
-                canAddNote.add(true);
+        )) {
+            if (cursor != null && cursor.getCount() != 0) {
+                LinkedHashSet<Long> queryChecksums = findChecksumsInQuery(
+                        cursor,
+                        noteOptions.getDuplicateScope().equals("deck"),
+                        deckIds
+                );
+                if (queryChecksums.contains(checksum)) {
+                    return new CanAddWithError(false, CAN_ADD_ERROR_DUPLICATE);
+                }
             }
+            return new CanAddWithError(true, null);
+        } catch (Exception e) {
+            return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
         }
-        else {
-            LinkedHashSet<Long> queryChecksums = findChecksumsInQuery(
-                    cursor,
-                    noteOptions.getDuplicateScope().equals("deck"), deckIds);
+    }
 
-            for (int i = 0; i < checksums.size(); i++) {
-                boolean isChecksumFound = !queryChecksums.contains(checksums.get(i));
-                canAddNote.add(isChecksumFound);
-            }
+    private boolean canAddNote(NoteRequest note) {
+        try {
+            return canAddNodeCheck(note).isCanAdd();
+        } catch (Exception e) {
+            return false;
         }
+    }
 
-        return canAddNote;
+    public List<Boolean> canAddNotes(ArrayList<NoteRequest> notesToTest) {
+        return notesToTest.stream().map(this::canAddNote).collect(Collectors.toList());
     }
 
     private LinkedHashSet<Long> findChecksumsInQuery(Cursor cursor, boolean isDuplicateScopeDeck, Set<Long> deckIds) {
@@ -232,22 +248,16 @@ public class IntegratedAPI {
         }
     }
 
-    public List<CanAddWithError> canAddNotesWithErrorDetail(ArrayList<NoteRequest> notesToTest) throws Exception {
-        List<CanAddWithError> canAddWithErrorList = new ArrayList<>();
-        List<Boolean> canAddList = canAddNotes(notesToTest);
-
-        for (boolean canAdd : canAddList) {
-            CanAddWithError canAddWithError;
-            if (canAdd) {
-                canAddWithError = new CanAddWithError(true, null);
-            }
-            else {
-                canAddWithError = new CanAddWithError(false, CAN_ADD_ERROR_REASON);
-            }
-            canAddWithErrorList.add(canAddWithError);
+    private CanAddWithError canAddNoteWithErrorDetail(NoteRequest note) {
+        try {
+            return canAddNodeCheck(note);
+        } catch (Exception e) {
+            return new CanAddWithError(false, CAN_ADD_ERROR_UNKNOWN);
         }
+    }
 
-        return canAddWithErrorList;
+    public List<CanAddWithError> canAddNotesWithErrorDetail(ArrayList<NoteRequest> notesToTest) {
+        return notesToTest.stream().map(this::canAddNoteWithErrorDetail).collect(Collectors.toList());
     }
 
     /**

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/NoteRequest.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/NoteRequest.java
@@ -103,9 +103,13 @@ public class NoteRequest {
         ArrayList<String> tagList = new ArrayList<>();
         JsonObject noteObject = noteElement.getAsJsonObject();
 
+        String field = null;
+        String value = null;
         JsonObject fieldsObject = noteObject.get("fields").getAsJsonObject();
-        String field = fieldsObject.keySet().toArray()[0].toString();
-        String value = fieldsObject.get(field).getAsString();
+        if (!fieldsObject.keySet().isEmpty()) {
+            field = fieldsObject.keySet().toArray()[0].toString();
+            value = fieldsObject.get(field).getAsString();
+        }
 
         String modelName = noteObject.get("modelName").getAsString();
         String deckName = noteObject.get("deckName").getAsString();


### PR DESCRIPTION
This was mainly made to address the issue mentioned #87, but there are also a few additional changes. This probably broke when Yomitan added support for more than two card formats https://github.com/yomidevs/yomitan/pull/1930.

By default Yomitan sets up three Anki card formats. If one of the formats is not configured, it will still get queried into Ankiconnect with an empty deck name, model name and fields array. This works fine on Ankiconnect desktop, as it will only validate the input and throw an Exception after canAddNote calls [createNote](https://git.sr.ht/~foosoft/anki-connect/tree/master/item/plugin/__init__.py#L289), but did not work in Ankiconnect Android, because it parses the note first, and [accesses the fields array](https://github.com/KamWithK/AnkiconnectAndroid/blob/d79d7543df63894cac726f255780369cd0e6b177/app/src/main/java/com/kamwithk/ankiconnectandroid/request_parsers/NoteRequest.java#L106) without checking whether this has any entries. 

field and value now default to null and are only updated when the fields array is not empty.

The previous implementation of canAddNotes from #60 assumed that note options and model are the same for all notes Yomitan which is not the case anymore. This PR addresses this, and also implements the remaining error messages for canAddNotesWithError.