### PR TITLE
Allow multiple trusted CORS hosts instead of only one

### DIFF
--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/SettingsActivity.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/SettingsActivity.java
@@ -83,7 +83,7 @@ public class SettingsActivity extends AppCompatActivity {
             }
 
 
-            EditTextPreference corsHostPreference = findPreference("cors_hostname");
+            EditTextPreference corsHostPreference = findPreference("cors_host");
             if (corsHostPreference != null) {
                 corsHostPreference.setOnBindEditTextListener(editText -> editText.setHint("e.g. http://example.com"));            }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/SettingsActivity.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/SettingsActivity.java
@@ -83,7 +83,7 @@ public class SettingsActivity extends AppCompatActivity {
             }
 
 
-            EditTextPreference corsHostPreference = findPreference("cors_host");
+            EditTextPreference corsHostPreference = findPreference("cors_hostname");
             if (corsHostPreference != null) {
                 corsHostPreference.setOnBindEditTextListener(editText -> editText.setHint("e.g. http://example.com"));            }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -122,10 +122,8 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
 
         // Else, allow the first host (to somewhat keep old behavior for backwards compatibility)
         String firstHost = normalizedAllowedHosts.get(0);
-        if (!firstHost.isEmpty()) {
-            rep.addHeader("Access-Control-Allow-Origin", firstHost);
-            rep.addHeader("Access-Control-Allow-Headers", "*");
-        }
+        rep.addHeader("Access-Control-Allow-Origin", firstHost);
+        rep.addHeader("Access-Control-Allow-Headers", "*");
     }
 
     // Trim and remove trailing slash from a host

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -122,8 +122,10 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
 
         // Else, allow the first host (to somewhat keep old behavior for backwards compatibility)
         String firstHost = normalizedAllowedHosts.get(0);
-        rep.addHeader("Access-Control-Allow-Origin", firstHost);
-        rep.addHeader("Access-Control-Allow-Headers", "*");
+        if (!firstHost.isEmpty()) {
+            rep.addHeader("Access-Control-Allow-Origin", firstHost);
+            rep.addHeader("Access-Control-Allow-Headers", "*");
+        }
     }
 
     // Trim and remove trailing slash from a host

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -98,7 +98,6 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
         if (origin == null) {
             origin = headers.get("Origin");
         }
-        String normalizedOrigin = normalizeHost(origin);
 
         String[] allowedHosts = corsHostsString.split("\\r?\\n");
         List<String> normalizedAllowedHosts = Arrays.stream(allowedHosts)
@@ -114,6 +113,7 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
         }
 
         // Check if the origin matches any of the allowed hosts
+        String normalizedOrigin = normalizeHost(origin);
         if (normalizedAllowedHosts.contains(normalizedOrigin)) {
             rep.addHeader("Access-Control-Allow-Origin", origin);
             rep.addHeader("Access-Control-Allow-Headers", "*");

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -114,10 +114,6 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
             applyHeaders(rep, origin);
             return;
         }
-
-        // Else, allow the first host (to somewhat keep old behavior for backwards compatibility)
-        String firstHost = normalizedAllowedHosts.get(0);
-        applyHeaders(rep, firstHost);
     }
 
     private void applyHeaders(NanoHTTPD.Response rep, String allowOrigin) {

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -107,22 +107,24 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
 
         // If "*" is in the allowed hosts, allow all origins
         if (normalizedAllowedHosts.contains("*")) {
-            rep.addHeader("Access-Control-Allow-Origin", "*");
-            rep.addHeader("Access-Control-Allow-Headers", "*");
+            applyHeaders(rep, "*");
             return;
         }
 
         // Check if the origin matches any of the allowed hosts
         String normalizedOrigin = normalizeHost(origin);
         if (normalizedAllowedHosts.contains(normalizedOrigin)) {
-            rep.addHeader("Access-Control-Allow-Origin", origin);
-            rep.addHeader("Access-Control-Allow-Headers", "*");
+            applyHeaders(rep, origin);
             return;
         }
 
         // Else, allow the first host (to somewhat keep old behavior for backwards compatibility)
         String firstHost = normalizedAllowedHosts.get(0);
-        rep.addHeader("Access-Control-Allow-Origin", firstHost);
+        applyHeaders(rep, firstHost);
+    }
+
+    private void applyHeaders(NanoHTTPD.Response rep, String allowOrigin) {
+        rep.addHeader("Access-Control-Allow-Origin", allowOrigin);
         rep.addHeader("Access-Control-Allow-Headers", "*");
     }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -102,17 +102,12 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
 
-        // If "*" is in the allowed hosts, allow all origins
         if (normalizedAllowedHosts.contains("*")) {
+            // Since "*" is in the allowed hosts, simply allow all origins
             applyHeaders(rep, "*");
-            return;
-        }
-
-        // Check if the origin matches any of the allowed hosts
-        String normalizedOrigin = normalizeHost(origin);
-        if (normalizedAllowedHosts.contains(normalizedOrigin)) {
+        } else if (normalizedAllowedHosts.contains(normalizeHost(origin))) {
+            // Request is from an origin the user trusts.
             applyHeaders(rep, origin);
-            return;
         }
     }
 

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -95,9 +95,6 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
 
         Map<String, String> headers = session.getHeaders();
         String origin = headers.get("origin");
-        if (origin == null) {
-            origin = headers.get("Origin");
-        }
 
         String[] allowedHosts = corsHostsString.split("\\r?\\n");
         List<String> normalizedAllowedHosts = Arrays.stream(allowedHosts)

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -96,7 +96,7 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
         Map<String, String> headers = session.getHeaders();
         String origin = headers.get("origin");
 
-        String[] allowedHosts = corsHostsString.split("\\r?\\n");
+        String[] allowedHosts = corsHostsString.split("\\n");
         List<String> normalizedAllowedHosts = Arrays.stream(allowedHosts)
                 .map(this::normalizeHost)
                 .filter(s -> !s.isEmpty())

--- a/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
+++ b/app/src/main/java/com/kamwithk/ankiconnectandroid/routing/RouteHandler.java
@@ -105,7 +105,7 @@ public class RouteHandler extends RouterNanoHTTPD.DefaultHandler {
         if (normalizedAllowedHosts.contains("*")) {
             // Since "*" is in the allowed hosts, simply allow all origins
             applyHeaders(rep, "*");
-        } else if (normalizedAllowedHosts.contains(normalizeHost(origin))) {
+        } else if (normalizedAllowedHosts.contains(origin)) {
             // Request is from an origin the user trusts.
             applyHeaders(rep, origin);
         }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -24,10 +24,10 @@
 
         <EditTextPreference
                 app:iconSpaceReserved="false"
-                app:dialogMessage="Enter the hostname you want to allow access from."
-                app:dialogTitle="Enter CORS Host"
+                app:dialogMessage="Enter the hostnames you want to allow access from. Each hostname should be on a new line."
+                app:dialogTitle="Enter CORS Hosts"
                 app:key="cors_host"
-                app:title="CORS Host"
+                app:title="CORS Hosts"
                 app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>


### PR DESCRIPTION
Currently, the user can only have one trusted host. My use case is that I want to add, for example, Mokuro Reader, asbplayer, and Mangatan to the CORS hosts instead of only one of them. Right now, the user is forced to either enable all with `"*"`, which is insecure, or they're forced to switch between `https://app.mokuro.reader`, `https://app.asbplayer.dev`, and `http://wherever-theyre-hosting-mangatan:4568`, which is quite inconvenient.

Also, the example text that should show up for the CORS setting was not being displayed due to a mismatch of strings, so that's also fixed.