### PR TITLE
Add Release Workflow to reduce maintainers burden

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Publish Signed Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Select release type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - major
+          - minor
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Determine New Version
+        id: versioning
+        run: |
+          # Fetch all tags to ensure we see the latest release
+          git fetch --tags
+          # Get the highest version tag (e.g., 2.0), ignoring non-version tags
+          LATEST_TAG=$(git tag -l | grep -E '^[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+          
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="1.0"
+          fi
+          
+          MAJOR=$(echo $LATEST_TAG | cut -d. -f1)
+          MINOR=$(echo $LATEST_TAG | cut -d. -f2)
+          
+          if [ "${{ github.event.inputs.version_type }}" == "major" ]; then
+            NEW_VERSION="$((MAJOR + 1)).0"
+          else
+            NEW_VERSION="${MAJOR}.$((MINOR + 1))"
+          fi
+          
+          # Replace the dot with an underscore for the filename
+          FILENAME_VERSION=$(echo $NEW_VERSION | tr '.' '_')
+          
+          echo "new_tag=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "file_version=$FILENAME_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Decode Keystore
+        run: echo "${{ secrets.ANDROID_SIGNING_KEY }}" | base64 --decode > app/release.keystore
+
+      - name: Grant Execute Permission
+        run: chmod +x gradlew
+
+      - name: Build Signed APK
+        run: |
+          ./gradlew assembleRelease
+          # Rename the file to ankiconnect_android_X_Y.apk
+          mv app/build/outputs/apk/release/app-release.apk \
+             app/build/outputs/apk/release/ankiconnect_android_${{ steps.versioning.outputs.file_version }}.apk
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.versioning.outputs.new_tag }}
+          name: Release ${{ steps.versioning.outputs.new_tag }}
+          body: "" 
+          draft: false
+          prerelease: false
+          files: app/build/outputs/apk/release/ankiconnect_android_*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,13 +19,23 @@ android {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
         }
+    }
 
+    signingConfigs {
+        release {
+            // This looks for the file we will decode in the GitHub Action
+            storeFile file("release.keystore")
+            storePassword System.getenv("KEYSTORE_PASSWORD")
+            keyAlias System.getenv("KEY_ALIAS")
+            keyPassword System.getenv("KEY_PASSWORD")
+        }
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
 


### PR DESCRIPTION
Here is a github workflow to help you with releases, I know doing tedious stuff like that is tedious, so I hope this helps <3




Here are some instructions if needed written by ai for reference on how to generate the secrets if needed
```
1. Generate a New Keystore
If you do not have a keystore file yet, run this command in your terminal. It will create a file named release.keystore.

Bash

keytool -genkey -v -keystore release.keystore -alias ankiconnect_key -keyalg RSA -keysize 2048 -validity 10000
Password: You will be prompted to create a password. Remember this for KEYSTORE_PASSWORD and KEY_PASSWORD.

Alias: The command above sets the alias to ankiconnect_key.

Details: You can press Enter to skip the organizational questions.

2. Encode Keystore for GitHub
GitHub Secrets cannot store binary files, so you must convert the .keystore file into a text string.

For Mac or Linux:

Bash

base64 -w 0 release.keystore > secrets_to_copy.txt
For Windows (PowerShell):

PowerShell

[Convert]::ToBase64String([System.IO.File]::ReadAllBytes("release.keystore")) | Out-File -FilePath secrets_to_copy.txt
3. Add Secrets to GitHub
Open your repository on GitHub.

Go to Settings > Secrets and variables > Actions.

Click New repository secret for each of the following:

Name: ANDROID_SIGNING_KEY Value: (Copy the entire long text string from secrets_to_copy.txt)

Name: KEY_ALIAS Value: ankiconnect_key

Name: KEYSTORE_PASSWORD Value: (The password you created in Step 1)

Name: KEY_PASSWORD Value: (The password you created in Step 1)

4. Enable Workflow Permissions
You must allow the built-in GITHUB_TOKEN to create releases.

In your repository Settings, go to Actions > General.

Scroll to Workflow permissions.

Select Read and write permissions.

Click Save.
```